### PR TITLE
Add Flatpak warning to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 A simple plugin for rhythmbox to update your rich presence in discord.
 This is based off of the built-in im-status plugin and has some borrowed code; credit where credit is due!
 
+Note: This plugin does not work with Discord installed via Flatpak.
+
 ## Usage
 - Install `pypresence`:
 


### PR DESCRIPTION
I added a warning in the readme to let users know that this plugin won't work with the version of Discord installed via Flatpak, since that version is sandboxed.